### PR TITLE
Added frontend coverage workflow for PRs and main README

### DIFF
--- a/.github/workflows/frontend_coverage.yaml
+++ b/.github/workflows/frontend_coverage.yaml
@@ -10,7 +10,7 @@ on:
       - "src/application/frontend/**"
 
 jobs:
-  coverage:
+  pr_comment_and_badge:
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -34,25 +34,48 @@ jobs:
       - name: Run Jest Coverage
         run: npm run test:ci
 
-      - name: Upload Coverage Artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: frontend-coverage
-          path: coverage
-
-      - name: Extract Coverage Percentage
+      - name: Extract Coverage Metrics
         id: cov
         run: |
-          total=$(jq '.total.lines.pct' coverage/coverage-summary.json)
-          echo "pct=$total" >> $GITHUB_OUTPUT
+          lines=$(jq '.total.lines.pct' coverage/coverage-summary.json)
+          branches=$(jq '.total.branches.pct' coverage/coverage-summary.json)
+          functions=$(jq '.total.functions.pct' coverage/coverage-summary.json)
+          statements=$(jq '.total.statements.pct' coverage/coverage-summary.json)
 
-      - name: Comment Coverage on PR
+          echo "lines=$lines" >> $GITHUB_OUTPUT
+          echo "branches=$branches" >> $GITHUB_OUTPUT
+          echo "functions=$functions" >> $GITHUB_OUTPUT
+          echo "statements=$statements" >> $GITHUB_OUTPUT
+
+          # Pretty text form for collapsible details
+          cat coverage/lcov-report/index.html | sed 's/<[^>]*>//g' | head -n 200 > coverage.txt
+          echo "text_report<<EOF" >> $GITHUB_OUTPUT
+          cat coverage.txt >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Comment on PR
         if: github.event_name == 'pull_request'
         uses: peter-evans/create-or-update-comment@v4
         with:
           issue-number: ${{ github.event.pull_request.number }}
           body: |
-            **Frontend Coverage:** ${{ steps.cov.outputs.pct }}%
+            **Frontend Test Coverage**
+
+            | Metric | Value |
+            |--------|-------|
+            | Lines | **${{ steps.cov.outputs.lines }}%** |
+            | Statements | **${{ steps.cov.outputs.statements }}%** |
+            | Branches | **${{ steps.cov.outputs.branches }}%** |
+            | Functions | **${{ steps.cov.outputs.functions }}%** |
+
+            <details>
+            <summary>Coverage Report Summary</summary>
+
+            ```
+            ${{ steps.cov.outputs.text_report }}
+            ```
+
+            </details>
 
       - name: Generate Badge
         if: github.ref == 'refs/heads/main'

--- a/.github/workflows/frontend_coverage.yaml
+++ b/.github/workflows/frontend_coverage.yaml
@@ -32,9 +32,9 @@ jobs:
         run: npm ci
 
       - name: Run Jest Coverage
-        run: npm run test:ci
+        run: npm run test:ci | tee coverage-summary.txt
 
-      - name: Extract Coverage Metrics
+      - name: Extract Coverage Metrics Table
         id: cov
         run: |
           lines=$(jq '.total.lines.pct' coverage/coverage-summary.json)
@@ -51,6 +51,13 @@ jobs:
           cat coverage/lcov-report/index.html | sed 's/<[^>]*>//g' | head -n 200 > coverage.txt
           echo "text_report<<EOF" >> $GITHUB_OUTPUT
           cat coverage.txt >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Extract Coverage Metrics Summary
+        id: covtext
+        run: |
+          echo "text<<EOF" >> $GITHUB_OUTPUT
+          cat coverage-summary.txt >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Comment on PR
@@ -72,7 +79,7 @@ jobs:
             <summary>Coverage Report Summary</summary>
 
             ```
-            ${{ steps.cov.outputs.text_report }}
+            ${{ steps.covtext.outputs.text }}
             ```
 
             </details>

--- a/.github/workflows/frontend_coverage.yaml
+++ b/.github/workflows/frontend_coverage.yaml
@@ -1,0 +1,82 @@
+name: Frontend Code Coverage
+
+on:
+  pull_request:
+    paths:
+      - "src/application/frontend/**"
+  push:
+    branches: [main]
+    paths:
+      - "src/application/frontend/**"
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./src/application/frontend
+
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.10.0
+
+      - name: Install Dependencies
+        run: npm ci
+
+      - name: Run Jest Coverage
+        run: npm run test:ci
+
+      - name: Upload Coverage Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: frontend-coverage
+          path: coverage
+
+      - name: Extract Coverage Percentage
+        id: cov
+        run: |
+          total=$(jq '.total.lines.pct' coverage/coverage-summary.json)
+          echo "pct=$total" >> $GITHUB_OUTPUT
+
+      - name: Comment Coverage on PR
+        if: github.event_name == 'pull_request'
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            **Frontend Coverage:** ${{ steps.cov.outputs.pct }}%
+
+      - name: Generate Badge
+        if: github.ref == 'refs/heads/main'
+        run: |
+          pct="${{ steps.cov.outputs.pct }}"
+          color="red"
+          if (( $(echo "$pct >= 80" | bc -l) )); then color="yellow"; fi
+          if (( $(echo "$pct >= 90" | bc -l) )); then color="green"; fi
+
+          mkdir -p ../../../.github/badges
+          cat > ../../../.github/badges/frontend-coverage.svg <<EOF
+          <svg xmlns="http://www.w3.org/2000/svg" width="150" height="20">
+            <rect width="90" height="20" fill="#555"/>
+            <rect x="90" width="60" height="20" fill="$color"/>
+            <text x="45" y="14" fill="#fff" font-family="DejaVu Sans" font-size="11" text-anchor="middle">coverage</text>
+            <text x="120" y="14" fill="#fff" font-family="DejaVu Sans" font-size="11" text-anchor="middle">${pct}%</text>
+          </svg>
+          EOF
+
+      - name: Commit badge
+        if: github.ref == 'refs/heads/main'
+        run: |
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+          git add ../../../.github/badges/frontend-coverage.svg
+          git commit -m "Update frontend coverage badge" || exit 0
+          git push

--- a/.github/workflows/frontend_coverage.yaml
+++ b/.github/workflows/frontend_coverage.yaml
@@ -34,6 +34,12 @@ jobs:
       - name: Run Jest Coverage
         run: npm run test:ci | tee coverage-summary.txt
 
+      - name: Extract Coverage Percentage
+        id: covpct
+        run: |
+          total=$(jq '.total.lines.pct' coverage/coverage-summary.json)
+          echo "pct=$total" >> $GITHUB_OUTPUT
+
       - name: Extract Coverage Metrics Table
         id: cov
         run: |
@@ -70,10 +76,10 @@ jobs:
 
             | Metric | Value |
             |--------|-------|
-            | Lines | **${{ steps.cov.outputs.lines }}%** |
             | Statements | **${{ steps.cov.outputs.statements }}%** |
             | Branches | **${{ steps.cov.outputs.branches }}%** |
             | Functions | **${{ steps.cov.outputs.functions }}%** |
+            | Lines | **${{ steps.cov.outputs.lines }}%** |
 
             <details>
             <summary>Coverage Report Summary</summary>
@@ -87,7 +93,7 @@ jobs:
       - name: Generate Badge
         if: github.ref == 'refs/heads/main'
         run: |
-          pct="${{ steps.cov.outputs.pct }}"
+          pct="${{ steps.covpct.outputs.pct }}"
           color="red"
           if (( $(echo "$pct >= 80" | bc -l) )); then color="yellow"; fi
           if (( $(echo "$pct >= 90" | bc -l) )); then color="green"; fi

--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # AIDoctors
+
 Your medical first point of contact
+
+## Coverage
+
+![Frontend Coverage](.github/badges/frontend-coverage.svg)

--- a/src/application/frontend/jest.config.ts
+++ b/src/application/frontend/jest.config.ts
@@ -11,7 +11,7 @@ const config: Config = {
   collectCoverage: true,
 
   // A list of reporter names that Jest uses when writing coverage reports
-  coverageReporters: ['text-summary', 'lcov', 'json-summary'],
+  coverageReporters: ['text', 'lcov', 'json-summary'],
 
   // The directory where Jest should output its coverage files
   coverageDirectory: './coverage',

--- a/src/application/frontend/jest.config.ts
+++ b/src/application/frontend/jest.config.ts
@@ -11,7 +11,7 @@ const config: Config = {
   collectCoverage: true,
 
   // A list of reporter names that Jest uses when writing coverage reports
-  coverageReporters: ['text', 'lcov', 'json-summary'],
+  coverageReporters: ['text-summary', 'lcov', 'json-summary'],
 
   // The directory where Jest should output its coverage files
   coverageDirectory: './coverage',

--- a/src/application/frontend/jest.config.ts
+++ b/src/application/frontend/jest.config.ts
@@ -10,6 +10,9 @@ const config: Config = {
   // Indicates whether the coverage information should be collected while executing the test
   collectCoverage: true,
 
+  // A list of reporter names that Jest uses when writing coverage reports
+  coverageReporters: ['text', 'lcov', 'json-summary'],
+
   // The directory where Jest should output its coverage files
   coverageDirectory: './coverage',
 


### PR DESCRIPTION
Added a GitHub workflow to automatically add a code coverage report as a comment in PRs that touch the frontend and update a code coverage badge in the main README.